### PR TITLE
✨ How might we frame the DUNA up on a tee (before the donation) to establish competence like in the Lawson paper?

### DIFF
--- a/examinations/response-8.md
+++ b/examinations/response-8.md
@@ -409,3 +409,8 @@ BlockTrans could consult OFAC’s website at http://home.treasury.gov/policy-iss
 
 
 
+#  Stretch
+
+## SRO as core of market and invvestor  ptoections
+
+although seemed more interested during all the  meetingsi n funcitnal operations rather than investor rights


### PR DESCRIPTION
If I can get this in (_see referenced WHYDRSS comment item below_), then I think we are in a much stronger position come next year's comment letter. _If_ this is the last time staff chose to communicate on the governance implications from Exhibit 6.2.5, then it could really help to establish competency early on. _See also_ direct deference to niche specialized authority from [Chair Atkins](https://x.com/blocktransfer/status/1939364667455082630).
